### PR TITLE
Add watcher api methods

### DIFF
--- a/testobject/testobject.py
+++ b/testobject/testobject.py
@@ -8,6 +8,7 @@ import requests
 
 from .devices import Devices
 from .suites import Suites
+from .watcher import Watcher
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +23,7 @@ class TestObject(object):
 		self.api_key = api_key
 		self.devices = Devices(self)
 		self.suites = Suites(self)
+		self.watcher = Watcher(self)
 
 	def request(self, method, endpoint, auth_type=None, data=None):
 		url = TestObject.URL_BASE + endpoint

--- a/testobject/testobject.py
+++ b/testobject/testobject.py
@@ -27,16 +27,21 @@ class TestObject(object):
 		url = TestObject.URL_BASE + endpoint
 		logger.info("URL: %s",url)
 
-		content = None
+		auth = None
 
 		#Appium Suites API needs a different authentication
 		# "All endpoints in Appium Suites API require basic authentication with
 		# the API Key as the username and the password left blank."
+		# Watcher API needs no authentication
 		if auth_type == 'suite':
-			content = requests.request(method, url, auth=(self.api_key, ''), json=data)
+			auth=(self.api_key, '')
+		elif auth_type == 'watcher':
+			pass
 		else:
-			content = requests.request(method, url, auth=(self.username, self.api_key), json=data)
+			auth=(self.username, self.api_key)
+
+		content = requests.request(method, url, auth=auth, json=data)
 
 		logger.debug("content: %s", content)
 
-		return json.loads(content.text)
+		return content

--- a/testobject/watcher.py
+++ b/testobject/watcher.py
@@ -1,0 +1,26 @@
+class Watcher(object):
+
+	def __init__(self, testobject):
+		self.testobject = testobject
+
+	def skip_test_report(self, session_id):
+		method = 'PUT'
+		
+		endpoint = '/v2/appium/session/{session_id}/skiptest'.format(session_id=session_id)
+
+		content = self.testobject.request(method, endpoint, auth_type='watcher')
+
+		return content
+		
+
+	def report_test_result(self, session_id, passed):
+		method = 'PUT'
+
+		endpoint = '/v2/appium/session/{session_id}/test'.format(session_id=session_id)
+
+		data = {}
+		data['passed'] = passed
+
+		content = self.testobject.request(method, endpoint, auth_type='watcher', data=data)
+
+		return content

--- a/tests/test_testobject.py
+++ b/tests/test_testobject.py
@@ -87,3 +87,17 @@ def test_skip_test(to):
     response = to.suites.skip_suite_test(14, 11, 63)
 
     assert response.json(), dict
+
+@vcr.use_cassette('tests/vcr_cassettes/skip-test-report.yml', filter_headers=['authorization'])
+def test_skip_test_report(to):
+    
+    response = to.watcher.skip_test_report('95ffffe9-4eb0-418e-87d0-4f1d59fa19fe')
+
+    assert response.ok 
+
+@vcr.use_cassette('tests/vcr_cassettes/report-test-result.yml', filter_headers=['authorization'])
+def test_report_test_result(to):
+    response = to.watcher.report_test_result('95ffffe9-4eb0-418e-87d0-4f1d59fa19fe', False)
+
+    assert response.ok 
+

--- a/tests/test_testobject.py
+++ b/tests/test_testobject.py
@@ -17,7 +17,7 @@ def test_get_devices(to):
     response = to.devices.get_devices()
 
 
-    assert response, dict
+    assert response.json(), dict
 
 
 @vcr.use_cassette('tests/vcr_cassettes/available-devices.yml', filter_headers=['authorization'])
@@ -26,7 +26,7 @@ def test_get_available_devices(to):
     response = to.devices.get_available_devices()
 
 
-    assert response, dict
+    assert response.json(), dict
 
 
 @vcr.use_cassette('tests/vcr_cassettes/device.yml', filter_headers=['authorization'])
@@ -37,8 +37,8 @@ def test_get_device(to):
     response = to.devices.get_device(device_name)
 
 
-    assert response, dict
-    assert response['US']['id'] == device_name
+    assert response.json(), dict
+    assert response.json()['US']['id'] == device_name
 
 
 @vcr.use_cassette('tests/vcr_cassettes/get-device-ids.yml', filter_headers=['authorization'])
@@ -46,7 +46,7 @@ def test_get_devices_ids(to):
 
     response = to.suites.get_devices_ids(14)
 
-    assert response, dict
+    assert response.json(), dict
 
 @vcr.use_cassette('tests/vcr_cassettes/update-suite.yml', filter_headers=['authorization'])
 def test_update_suite(to):
@@ -56,7 +56,7 @@ def test_update_suite(to):
 
     response = to.suites.update_suite(14, data)
 
-    assert response, dict
+    assert response.json(), dict
 
 @vcr.use_cassette('tests/vcr_cassettes/start-suite.yml', filter_headers=['authorization'])
 def test_start_suite(to):
@@ -65,25 +65,25 @@ def test_start_suite(to):
 
     response = to.suites.start_suite(14, data)
 
-    assert response, dict
+    assert response.json(), dict
 
 @vcr.use_cassette('tests/vcr_cassettes/stop-suite.yml', filter_headers=['authorization'])
 def test_stop_suite(to):
 
     response = to.suites.stop_suite(14, 17)
 
-    assert response, dict
+    assert response.json(), dict
 
 @vcr.use_cassette('tests/vcr_cassettes/stop-suite-test.yml', filter_headers=['authorization'])
 def stop_suite_test(to):
 
     response = to.suites.stop_suite_test(14, 17, 63, True)
 
-    assert response, dict
+    assert response.json(), dict
 
 @vcr.use_cassette('tests/vcr_cassettes/skip-suite-test.yml', filter_headers=['authorization'])
 def test_skip_test(to):
 
     response = to.suites.skip_suite_test(14, 11, 63)
 
-    assert response, dict
+    assert response.json(), dict

--- a/tests/vcr_cassettes/report-test-result.yml
+++ b/tests/vcr_cassettes/report-test-result.yml
@@ -1,0 +1,25 @@
+interactions:
+- request:
+    body: !!python/unicode '{"passed": false}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['17']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: PUT
+    uri: https://app.testobject.com/api/rest/v2/appium/session/95ffffe9-4eb0-418e-87d0-4f1d59fa19fe/test
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      content-security-policy: ['frame-ancestors https://*.testobject.com']
+      content-type: [application/json]
+      date: ['Sat, 07 Oct 2017 01:11:16 GMT']
+      referrer-policy: [no-referrer]
+      strict-transport-security: [max-age=31536000; includeSubDomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [SAMEORIGIN]
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+version: 1

--- a/tests/vcr_cassettes/skip-test-report.yml
+++ b/tests/vcr_cassettes/skip-test-report.yml
@@ -1,0 +1,24 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: PUT
+    uri: https://app.testobject.com/api/rest/v2/appium/session/95ffffe9-4eb0-418e-87d0-4f1d59fa19fe/skiptest
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      content-security-policy: ['frame-ancestors https://*.testobject.com']
+      content-type: [application/json]
+      date: ['Sat, 07 Oct 2017 01:11:16 GMT']
+      referrer-policy: [no-referrer]
+      strict-transport-security: [max-age=31536000; includeSubDomains; preload]
+      x-content-type-options: [nosniff]
+      x-frame-options: [SAMEORIGIN]
+      x-xss-protection: [1; mode=block]
+    status: {code: 204, message: No Content}
+version: 1


### PR DESCRIPTION
Fixes #5 and adds the remaining TestObject methods missing.
At this point the only ones not included are version 1 methods but since they are deprecated don't think they should be added.