### PR TITLE
Include MANIFEST file and prepare for 0.1.1 release

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.md
+recursive-include testobject *.py
+recursive-include tests

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # testobject-python-api
 
-[![Build Status](https://travis-ci.org/enriquegh/testobject-python-api.svg?branch=master)](https://travis-ci.org/enriquegh/testobject-python-api) [![codecov](https://codecov.io/gh/enriquegh/testobject-python-api/branch/master/graph/badge.svg)](https://codecov.io/gh/enriquegh/testobject-python-api)
+[![Build Status](https://travis-ci.org/enriquegh/testobject-python-api.svg?branch=master)](https://travis-ci.org/enriquegh/testobject-python-api) [![codecov](https://codecov.io/gh/enriquegh/testobject-python-api/branch/master/graph/badge.svg)](https://codecov.io/gh/enriquegh/testobject-python-api) [![PyPI version](https://badge.fury.io/py/testobject.svg)](https://badge.fury.io/py/testobject)
 
 A Python library client for TestObject API
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except(IOError, ImportError):
 setup(
     name = 'testobject',
     packages = ['testobject'],
-    version = '0.1.0',
+    version = '0.1.1',
     description = 'Python API wrapper for TestObject',
     author = 'Enrique Gonzalez',
     author_email = 'egonzalezh94@gmail.com',


### PR DESCRIPTION
Without explicitly adding the README.md file, the setup step was failing